### PR TITLE
change shell to bash

### DIFF
--- a/bin/run_python_code.sh
+++ b/bin/run_python_code.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 oldIFS=$IFS
 IFS=''
 arg_l_c=()

--- a/lib/python-run-terminalnx.js
+++ b/lib/python-run-terminalnx.js
@@ -82,7 +82,7 @@ function run() {
     }
 
     var child = child_process.spawn(sel_term, [
-        ex_op, "/bin/sh", __dirname + "/../bin/run_python_code.sh", file.path, c_l_a
+        ex_op, "/bin/bash", __dirname + "/../bin/run_python_code.sh", file.path, c_l_a
     ], {
         cwd: info.dir,
         detached: true


### PR DESCRIPTION
You are using /bin/sh to run your script, some systems, including debian/ubuntu based use dash as the /bin/sh executable, which is strictly compatible with the ash shell. You are using bash arrays in the script and should be using /bin/bash as the shell to run the script.